### PR TITLE
Bump version to v1.0.2

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,17 +1,23 @@
 <?php
 /*
 Plugin Name: Verify domain for Apple Pay with Stripe
+Plugin URI: https://github.com/memberful/verify-domain-for-apple-pay-with-stripe
 Description: Adds the domain association file to enable Apple Pay on the Web for your Stripe account.
-Version: 1.0.1
+Version: 1.0.2
+Requires at least: 4.1
+Requires PHP: 7.0
 Author: Memberful
 Author URI: https://memberful.com/
 License: GPLv2 or later
 */
 
 function memberful_show_apple_pay_domain_verification_file() {
-  if ( $_SERVER["REQUEST_URI"] == "/.well-known/apple-developer-merchantid-domain-association" ) {
-    readfile( dirname( __FILE__ ) . "/apple-developer-merchantid-domain-association");
-    exit();
+  if ( isset($_SERVER["REQUEST_URI"]) ) {
+    if ( urlencode($_SERVER["REQUEST_URI"]) === urlencode("/.well-known/apple-developer-merchantid-domain-association") ) {
+      readfile( __DIR__ . "/apple-developer-merchantid-domain-association");
+      exit();
+    }
   }
 }
-add_action( 'plugins_loaded', 'memberful_show_apple_pay_domain_verification_file' );
+
+add_action( "plugins_loaded", "memberful_show_apple_pay_domain_verification_file" );

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,10 @@
 === Verify domain for Apple Pay with Stripe ===
 Contributors: patrik bona, drewstrojny
 Tags: apple pay, stripe, domain verification, memberful
-Requires at least: 1.5.2
-Tested up to: 5.2
-Stable tag: 1.0.1
+Requires at least: 4.1
+Requires PHP: 7.0
+Tested up to: 6.1.1
+Stable tag: 1.0.2
 License: GPLv2 or later
 
 Adds the domain association file to enable Apple Pay on the Web for your Stripe account.
@@ -23,6 +24,12 @@ Adds [Stripe's domain association file](https://stripe.com/files/apple-pay/apple
 2. Go to your Stripe dashboard and add your domain from Account Settings => Apple Pay.
 
 == Changelog ==
+
+= 1.0.2 =
+
+* Escape and force strict comparison when checking $_SERVER["REQUEST_URI"]
+* Bumped minimum WP version to 4.1
+* Bumped minimum PHP version to 7.0
 
 = 1.0.1 =
 


### PR DESCRIPTION
* Escape and force strict comparison when checking `$_SERVER["REQUEST_URI"]`
* Bumped minimum WP version to 4.1
* Bumped minimum PHP version to 7.0